### PR TITLE
Avoid out of bounds errors when calling nvim_buf_get_text/nvim_buf_set_text

### DIFF
--- a/lua/treesitter-utils.lua
+++ b/lua/treesitter-utils.lua
@@ -1,5 +1,21 @@
 local M = {}
 
+---@param node TSNode
+---@param bufnr number | nil
+---@return number, number, number, number
+local get_node_range = function(node, bufnr)
+  local bufnr = bufnr or 0
+  local sr, sc, er, ec = node:range()
+  local last_row = vim.api.nvim_buf_line_count(bufnr) - 1
+  -- If the node is the last node in the buffer, then its end row and column might need
+  -- to be adjusted to avoid out-of-bounds error when calling nvim_buf_[set|get]_text
+  if er > last_row then
+    er = last_row
+    ec = #vim.api.nvim_buf_get_lines(bufnr, last_row, last_row + 1, false)[1]
+  end
+  return sr, sc, er, ec
+end
+
 --- Find parent node of given type.
 ---@param node TSNode
 ---@param type string
@@ -28,7 +44,7 @@ end
 ---@param text string | table
 ---@param bufnr number | nil
 M.set_node_text = function(node, text, bufnr)
-  local sr, sc, er, ec = node:range()
+  local sr, sc, er, ec = get_node_range(node, bufnr)
   local content = { text }
   if (type(text) == 'table') then content = text end
   vim.api.nvim_buf_set_text(bufnr or 0, sr, sc, er, ec, content)
@@ -37,12 +53,10 @@ end
 --- Get text of given node.
 ---@param node TSNode
 ---@param bufnr number | nil
----@return string | string[]
+---@return string[]
 M.get_node_text = function(node, bufnr)
-  local sr, sc, er, ec = node:range()
-  local text = vim.api.nvim_buf_get_text(bufnr or 0, sr, sc, er, ec, {})
-  if (#text == 1) then return text[1] end
-  return text
+  local sr, sc, er, ec = get_node_range(node, bufnr)
+  return vim.api.nvim_buf_get_text(bufnr or 0, sr, sc, er, ec, {})
 end
 
 return M


### PR DESCRIPTION
Hi @nfrid, I'm using your `markdown-togglecheck` plugin, and this PR fixes out of bounds errors when creating a checkbox on the last line in a file.

e.g. if your buffer contains a single line like:

```
- foo
```
...and you call `:lua require("markdown-togglecheck").toggle()`, then an out of bounds error is thrown. 

This is because the `TSNode` representing the `list_item` has an end row which is one-past-the-end, which is disallowed by `nvim_buf_get_text` and `nvim_buf_set_text`. The fix here is to clamp the end row/column to the last valid position in the buffer.

Additionally, `get_node_text` is adapted here to always return a table, the calling code in `markdown-togglecheck.lua` expects a table and fails when a string is returned. The alternative would be to alter the call site, but I figured I'd start with this approach.